### PR TITLE
Remove Jekyll

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This repo contains bits and bobs for use in Form.io [form manager configurations
         | `title` | (your title here) |
         | `logo` | `https://sf.gov/themes/custom/sfgovpl/logo.svg` |
         | `logoHeight` | `56` |
-        | `js` | `https://sfdigitalservices.github.io/formio-public-config/preview.js` |
+        | `js` | `https://cdn.jsdelivr.net/gh/SFDigitalServices/formio-public-config/preview.js` |
 
     Leave the "JSON" checkboxes unchecked.
 

--- a/_config.yml
+++ b/_config.yml
@@ -1,1 +1,0 @@
-theme: jekyll-theme-slate


### PR DESCRIPTION
This removes our Jekyll config file, which was causing longer build times than we need. Instead, I'm opting to use [jsDelivr](https://www.jsdelivr.com/?docs=gh) as the CDN for our JS, which allows us to point at versioned (by commit hash) URLs:

```
# no versioning, implies `@main`
https://cdn.jsdelivr.net/gh/SFDigitalServices/formio-public-config/preview.js
# branches are not advised because the TTL on these is long (not sure how long!)
https://cdn.jsdelivr.net/gh/SFDigitalServices/formio-public-config@main/preview.js
# commit shas are best because they're cached forever
https://cdn.jsdelivr.net/gh/SFDigitalServices/formio-public-config@ea5bbdf/preview.js
```

You can find the current commit hash for `preview.js` by [viewing it](https://github.com/SFDigitalServices/formio-public-config/blob/main/preview.js) and copying the text of the commit SHA from the upper right of the panel:

<img width="389" alt="image" src="https://user-images.githubusercontent.com/113896/188006154-d1160c86-b38a-493a-a056-4a283d8ff2f8.png">

Or by looking the [commits list](https://github.com/SFDigitalServices/formio-public-config/commits/main) and copying the SHA from the button on the right:

<img width="322" alt="image" src="https://user-images.githubusercontent.com/113896/188006289-3452db68-1e5b-48c3-b229-feb41d3456aa.png">
